### PR TITLE
Replace schemes with globals

### DIFF
--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-banner.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-banner.php
@@ -15,8 +15,8 @@ use Elementor\Group_Control_Image_Size;
 use Elementor\Group_Control_Css_Filter;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Text_Shadow;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Box_Shadow;
@@ -805,10 +805,9 @@ class Responsive_Addons_For_Elementor_Banner extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-banner-image-banner-desc .rael_banner_title' => 'color: {{VALUE}};',
 				),
@@ -820,7 +819,9 @@ class Responsive_Addons_For_Elementor_Banner extends Widget_Base {
 			array(
 				'name'     => 'rael_banner_title_typography',
 				'selector' => '{{WRAPPER}} .rael-banner-image-banner-desc .rael_banner_title',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -876,10 +877,9 @@ class Responsive_Addons_For_Elementor_Banner extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-banner .rael_banner_content' => 'color: {{VALUE}};',
 				),
@@ -891,7 +891,9 @@ class Responsive_Addons_For_Elementor_Banner extends Widget_Base {
 			array(
 				'name'     => 'rael_banner_content_typhography',
 				'selector' => '{{WRAPPER}} .rael-banner .rael_banner_content',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			)
 		);
 
@@ -935,10 +937,9 @@ class Responsive_Addons_For_Elementor_Banner extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-banner .rael-banner-link' => 'color: {{VALUE}};',
 				),
@@ -950,10 +951,9 @@ class Responsive_Addons_For_Elementor_Banner extends Widget_Base {
 			array(
 				'label'     => __( 'Hover Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-banner .rael-banner-link:hover' => 'color: {{VALUE}};',
 				),
@@ -964,7 +964,9 @@ class Responsive_Addons_For_Elementor_Banner extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'rael_banner_button_typhography',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-banner-link',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-business-hour.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-business-hour.php
@@ -13,7 +13,7 @@ use Elementor\Repeater;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Box_Shadow;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -376,7 +376,9 @@ class Responsive_Addons_For_Elementor_Business_Hour extends Widget_Base {
 			array(
 				'name'     => 'rael_title_typography',
 				'selector' => '{{WRAPPER}} .rael-business-hour-title h3',
-				'scheme'   => Typography::TYPOGRAPHY_2,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 			)
 		);
 
@@ -462,7 +464,9 @@ class Responsive_Addons_For_Elementor_Business_Hour extends Widget_Base {
 			array(
 				'name'     => 'rael_list_typography',
 				'selector' => '{{WRAPPER}} .rael-business-hour-item',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			)
 		);
 

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-button.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-button.php
@@ -8,16 +8,14 @@
 
 namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
-use Elementor\Plugin;
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Icons_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Text_Shadow;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -522,7 +520,9 @@ class Responsive_Addons_For_Elementor_Button extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'text_typography',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .rael-text',
 			)
 		);
@@ -560,7 +560,9 @@ class Responsive_Addons_For_Elementor_Button extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'hover_text_typography',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .rael-text',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-cf-styler.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-cf-styler.php
@@ -12,12 +12,12 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 use Responsive_Addons_For_Elementor\Traits\Missing_Dependency;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -233,10 +233,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Label Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'default'   => '',
 				'selectors' => array(
 					'{{WRAPPER}} .rael-cf7-style .wpcf7 form.wpcf7-form:not(input)' => 'color: {{VALUE}};',
@@ -249,10 +248,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Input Text / Placeholder Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-cf7-style .wpcf7 input:not([type=submit]),{{WRAPPER}} .rael-cf7-style .wpcf7 input::placeholder, {{WRAPPER}} .rael-cf7-style .wpcf7 select, {{WRAPPER}} .rael-cf7-style .wpcf7 textarea, {{WRAPPER}} .rael-cf7-style .wpcf7 textarea::placeholder,{{WRAPPER}} .rael-cf7-style .rael-cf7-select-custom:after' => 'color: {{VALUE}};',
 					'{{WRAPPER}}.elementor-widget-rael-cf7-styler .wpcf7-checkbox input[type="checkbox"]:checked + span:before, {{WRAPPER}}.elementor-widget-rael-cf7-styler .wpcf7-acceptance input[type="checkbox"]:checked + span:before' => 'color: {{VALUE}};',
@@ -511,10 +509,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Selected Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'condition' => array(
 					'radio_check_override!' => '',
 				),
@@ -533,10 +530,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Label Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'condition' => array(
 					'radio_check_override!' => '',
 				),
@@ -705,10 +701,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 				'types'          => array( 'classic', 'gradient' ),
 				'fields_options' => array(
 					'color' => array(
-						'scheme' => array(
-							'type'  => Color::get_type(),
-							'value' => Color::COLOR_4,
-						),
+						'global'   => [
+							'default' => Global_Colors::COLOR_ACCENT,
+						],
 					),
 				),
 				'selector'       => '{{WRAPPER}} .rael-cf7-style input[type="submit"]',
@@ -899,7 +894,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'cf7_message_typo',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-cf7-style span.wpcf7-not-valid-tip',
 			)
 		);
@@ -1038,7 +1035,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'cf7_validation_typo',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-cf7-style .wpcf7 .wpcf7-validation-errors, {{WRAPPER}} .rael-cf7-style div.wpcf7-mail-sent-ng,{{WRAPPER}} .rael-cf7-style .wpcf7-mail-sent-ok,{{WRAPPER}} .rael-cf7-style .wpcf7-acceptance-missing,{{WRAPPER}} .rael-cf7-style .wpcf7 form .wpcf7-response-output',
 			)
 		);
@@ -1120,7 +1119,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'form_label_typography',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-cf7-style .wpcf7 form.wpcf7-form label',
 			)
 		);
@@ -1138,7 +1139,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'input_typography',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-cf7-style .wpcf7 input:not([type=submit]), {{WRAPPER}} .rael-cf7-style .wpcf7 input::placeholder, {{WRAPPER}} .wpcf7 select,{{WRAPPER}} .rael-cf7-style .wpcf7 textarea, {{WRAPPER}} .rael-cf7-style .wpcf7 textarea::placeholder, {{WRAPPER}} .rael-cf7-style input[type=range]::-webkit-slider-thumb,{{WRAPPER}} .rael-cf7-style .rael-cf7-select-custom',
 			)
 		);
@@ -1156,7 +1159,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'button_typography',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-cf7-style input[type=submit]',
 			)
 		);
@@ -1177,7 +1182,9 @@ class Responsive_Addons_For_Elementor_Cf_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'radio_check_typography',
-				'scheme'    => Typography::TYPOGRAPHY_4,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'condition' => array(
 					'radio_check_override!' => '',
 				),

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-content-switcher.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-content-switcher.php
@@ -10,10 +10,10 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -466,10 +466,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 				'label'     => __( 'Color 1', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '#61CE70',
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-ct__slider' => 'background-color: {{VALUE}};',
 					'{{WRAPPER}} .rael-ct__toggle input[type="checkbox"] + label:before' => 'background-color: {{VALUE}};',
@@ -486,11 +485,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 				'label'     => __( 'Color 2', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '#7A7A7A',
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
-
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-ct__switcher:checked + .rael-ct__slider' => 'background-color: {{VALUE}};',
 					'{{WRAPPER}} .rael-ct__switcher:focus + .rael-ct__slider'     => '-webkit-box-shadow: 0 0 1px {{VALUE}};box-shadow: 0 0 1px {{VALUE}};',
@@ -506,10 +503,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 			array(
 				'label'     => __( 'Controller Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'default'   => '#ffffff',
 				'selectors' => array(
 					'{{WRAPPER}} .rael-ct__slider:before' => 'background-color: {{VALUE}};',
@@ -572,10 +568,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-ct__heading-1' => 'color: {{VALUE}};',
 				),
@@ -588,7 +583,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 			array(
 				'name'     => 'rael_ct_heading_1_typography',
 				'selector' => '{{WRAPPER}} .rael-ct__heading-1',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -606,10 +603,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-ct__heading-2' => 'color: {{VALUE}};',
 				),
@@ -622,7 +618,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 			array(
 				'name'     => 'rael_ct_heading_2_typography',
 				'selector' => '{{WRAPPER}} .rael-ct__heading-2',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -805,10 +803,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'condition' => array(
 					'rael_ct_content_1_content_type' => 'content',
 				),
@@ -823,7 +820,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 			array(
 				'name'      => 'rael_ct_content_1_typography',
 				'selector'  => '{{WRAPPER}} .rael-ct__content-1.rael-ct__section-1',
-				'scheme'    => Typography::TYPOGRAPHY_3,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'condition' => array(
 					'rael_ct_content_1_content_type' => 'content',
 				),
@@ -848,10 +847,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'condition' => array(
 					'rael_ct_content_2_content_type' => 'content',
 				),
@@ -866,7 +864,9 @@ class Responsive_Addons_For_Elementor_Content_Switcher extends Widget_Base {
 			array(
 				'name'      => 'rael_ct_content_2_typography',
 				'selector'  => '{{WRAPPER}} .rael-ct__content-2.rael-ct__section-2',
-				'scheme'    => Typography::TYPOGRAPHY_3,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'condition' => array(
 					'rael_ct_content_2_content_type' => 'content',
 				),

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-divider.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-divider.php
@@ -11,7 +11,7 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Typography;
 use Elementor\Utils;
@@ -687,7 +687,9 @@ class Responsive_Addons_For_Elementor_Divider extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'rael_divider_text_typography',
-				'scheme'    => Typography::TYPOGRAPHY_4,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector'  => '{{WRAPPER}} .rael-divider__text',
 				'condition' => array(
 					'rael_divider_type' => 'text',

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-fancy-text.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-fancy-text.php
@@ -9,9 +9,9 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Repeater;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Border;
 
@@ -310,7 +310,9 @@ class Responsive_Addons_For_Elementor_Fancy_Text extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'           => 'typography',
-				'scheme'         => Typography::TYPOGRAPHY_1,
+				'global'         => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'fields_options' => array(
 					'typography'  => array( 'default' => 'yes' ),
 					'font_size'   => array( 'default' => array( 'size' => 22 ) ),
@@ -415,7 +417,9 @@ class Responsive_Addons_For_Elementor_Fancy_Text extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'           => 'rael_fancy_text_strings_typography',
-				'scheme'         => Typography::TYPOGRAPHY_1,
+				'global'         => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'fields_options' => array(
 					'typography'  => array( 'default' => 'yes' ),
 					'font_size'   => array( 'default' => array( 'size' => 22 ) ),
@@ -543,7 +547,9 @@ class Responsive_Addons_For_Elementor_Fancy_Text extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'           => 'ending_typography',
-				'scheme'         => Typography::TYPOGRAPHY_1,
+				'global'         => [
+					'default'     => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'fields_options' => array(
 					'typography'  => array( 'default' => 'yes' ),
 					'font_size'   => array( 'default' => array( 'size' => 22 ) ),

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-faq.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-faq.php
@@ -12,8 +12,8 @@ use Elementor\Repeater;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
 use Elementor\Group_Control_Box_Shadow;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Icons_Manager;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -840,8 +840,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 			array(
 				'name'     => 'title_typography',
 				'selector' => '{{WRAPPER}} .rael-faq-accordion .rael-accordion-title .rael-question-span, {{WRAPPER}} .rael-faq-accordion .rael-accordion-title .rael-accordion-icon',
-				'scheme'   => Typography::TYPOGRAPHY_1,
-
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -889,10 +890,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 						{{WRAPPER}}  .rael-accordion-icon-closed, {{WRAPPER}} span.rael-accordion-icon-opened' => 'color: {{VALUE}};',
 					'{{WRAPPER}} .rael-accordion-icon-closed, {{WRAPPER}} span.rael-accordion-icon-opened' => 'fill: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 			)
 		);
 
@@ -905,10 +905,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 					'{{WRAPPER}} .rael-faq-accordion .rael-accordion-title.rael-title-active .rael-question-span,
 						{{WRAPPER}} span.rael-accordion-icon-opened' => 'color: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'condition' => array(
 					'rael_faq_layout' => 'accordion',
 				),
@@ -959,10 +958,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 					{{WRAPPER}}  .rael-accordion-icon-closed:hover' => 'color: {{VALUE}};',
 					'{{WRAPPER}} .rael-accordion-icon-closed:hover' => 'fill: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 			)
 		);
 
@@ -975,10 +973,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 					'{{WRAPPER}} .rael-faq-accordion .rael-accordion-title.rael-title-active:hover .rael-question-span,
 					{{WRAPPER}} span.rael-accordion-icon-opened:hover' => 'color: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'condition' => array(
 					'rael_faq_layout' => 'accordion',
 				),
@@ -1024,7 +1021,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 			array(
 				'name'     => 'content_typography',
 				'selector' => '{{WRAPPER}} .rael-faq-accordion .rael-accordion-content',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			)
 		);
 
@@ -1057,10 +1056,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 				'selectors' => array(
 					'{{WRAPPER}} .rael-faq-accordion .rael-accordion-content' => 'color: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 			)
 		);
 
@@ -1092,10 +1090,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 				'selectors' => array(
 					'{{WRAPPER}} .rael-faq-accordion .rael-accordion-content:hover' => 'color: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 			)
 		);
 
@@ -1160,10 +1157,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 					'{{WRAPPER}}  .rael-accordion-icon-closed' => 'color: {{VALUE}};',
 					'{{WRAPPER}} .rael-accordion-icon-closed' => 'fill: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 			)
 		);
 
@@ -1175,10 +1171,9 @@ class Responsive_Addons_For_Elementor_FAQ extends Widget_Base {
 				'selectors' => array(
 					'{{WRAPPER}} span.rael-accordion-icon-opened'  => 'color: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 			)
 		);
 

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-feature-list.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-feature-list.php
@@ -11,11 +11,11 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Repeater;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Utils;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 use Elementor\Icons_Manager;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -166,11 +166,9 @@ class Responsive_Addons_For_Elementor_Feature_List extends Widget_Base {
 			array(
 				'label'            => esc_html__( 'Icon Color', 'responsive-addons-for-elementor' ),
 				'type'             => Controls_Manager::COLOR,
-				'scheme'           => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
-				'fa4compatibility' => 'rael_feature_list_icon',
+				'global'           => [
+					'default'       => Global_Colors::COLOR_PRIMARY,
+				],
 				'condition'        => array(
 					'rael_icon_style' => 'on',
 				),
@@ -182,10 +180,9 @@ class Responsive_Addons_For_Elementor_Feature_List extends Widget_Base {
 			array(
 				'label'            => esc_html__( 'Icon Background', 'responsive-addons-for-elementor' ),
 				'type'             => Controls_Manager::COLOR,
-				'scheme'           => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'           => [
+					'default'       => Global_Colors::COLOR_PRIMARY,
+				],
 				'fa4compatibility' => 'rael_feature_list_icon',
 				'condition'        => array(
 					'rael_icon_style' => 'on',
@@ -197,10 +194,9 @@ class Responsive_Addons_For_Elementor_Feature_List extends Widget_Base {
 			array(
 				'label'            => esc_html__( 'Icon Box Background', 'responsive-addons-for-elementor' ),
 				'type'             => Controls_Manager::COLOR,
-				'scheme'           => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'           => [
+					'default'       => Global_Colors::COLOR_PRIMARY,
+				],
 				'fa4compatibility' => 'rael_feature_list_icon',
 				'condition'        => array(
 					'rael_icon_style' => 'on',
@@ -497,10 +493,9 @@ class Responsive_Addons_For_Elementor_Feature_List extends Widget_Base {
 			array(
 				'label'     => esc_html__( 'Connector Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'default'   => '#37368e',
 				'selectors' => array(
 					'{{WRAPPER}} .connector-type-classic .connector'  => 'border-color: {{VALUE}};',
@@ -806,10 +801,9 @@ class Responsive_Addons_For_Elementor_Feature_List extends Widget_Base {
 				'selectors' => array(
 					'{{WRAPPER}} .rael-feature-list-content-box .rael-feature-list-title, {{WRAPPER}} .rael-feature-list-content-box .rael-feature-list-title > a, {{WRAPPER}} .rael-feature-list-content-box .rael-feature-list-title:visited' => 'color: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 			)
 		);
 
@@ -818,7 +812,9 @@ class Responsive_Addons_For_Elementor_Feature_List extends Widget_Base {
 			array(
 				'name'     => 'rael_feature_list_title_typography',
 				'selector' => '{{WRAPPER}} .rael-feature-list-content-box .rael-feature-list-title, {{WRAPPER}} .rael-feature-list-content-box .rael-feature-list-title a',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -840,10 +836,9 @@ class Responsive_Addons_For_Elementor_Feature_List extends Widget_Base {
 				'selectors' => array(
 					'{{WRAPPER}} .rael-feature-list-content-box .rael-feature-list-content' => 'color: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 			)
 		);
 
@@ -852,7 +847,9 @@ class Responsive_Addons_For_Elementor_Feature_List extends Widget_Base {
 			array(
 				'name'           => 'rael_feature_list_description_typography',
 				'selector'       => '{{WRAPPER}} .rael-feature-list-content-box .rael-feature-list-content',
-				'scheme'         => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'fields_options' => array(
 					'font_size' => array(
 						'default' => array(

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-flip-box.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-flip-box.php
@@ -10,11 +10,11 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Utils;
 use Elementor\Group_Control_Image_Size;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Icons_Manager;
@@ -731,7 +731,9 @@ class Responsive_Addons_For_Elementor_Flip_Box extends Widget_Base {
 			array(
 				'name'     => 'front_title_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .rael-flip-box-front .rael-flip-box-layer-title',
 			)
 		);
@@ -764,7 +766,9 @@ class Responsive_Addons_For_Elementor_Flip_Box extends Widget_Base {
 			array(
 				'name'     => 'front_description_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-flip-box-front .rael-flip-box-layer-desc',
 			)
 		);
@@ -904,7 +908,9 @@ class Responsive_Addons_For_Elementor_Flip_Box extends Widget_Base {
 			array(
 				'name'      => 'back_title_typography',
 				'label'     => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_1,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector'  => '{{WRAPPER}} .rael-flip-box-back .rael-flip-box-layer-title',
 				'condition' => array( 'back_title_text!' => '' ),
 			)
@@ -953,7 +959,9 @@ class Responsive_Addons_For_Elementor_Flip_Box extends Widget_Base {
 			array(
 				'name'     => 'description_typography_b',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-flip-box-back .rael-flip-box-layer-desc',
 			)
 		);
@@ -1048,7 +1056,9 @@ class Responsive_Addons_For_Elementor_Flip_Box extends Widget_Base {
 			array(
 				'name'     => 'button_typography',
 				'label'    => esc_html__( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '{{WRAPPER}} .rael-flip-box-button',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-google-map.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-google-map.php
@@ -11,7 +11,7 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Repeater;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -607,7 +607,9 @@ class Responsive_Addons_For_Elementor_Google_Map extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'rael_info_window_title',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-google-map__info-window-title',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-icon-box.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-icon-box.php
@@ -13,8 +13,8 @@ use Elementor\Controls_Manager;
 use Elementor\Utils;
 use Elementor\Control_Media;
 use Elementor\Icons_Manager;
-use Elementor\Core\Schemes\Color;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Typography;
 use Elementor\Group_Control_Css_Filter;
 use Elementor\Group_Control_Background;
@@ -614,10 +614,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 				'selector'       => '{{WRAPPER}} .elementor-button',
 				'fields_options' => array(
 					'color' => array(
-						'scheme' => array(
-							'type'  => Color::get_type(),
-							'value' => Color::COLOR_4,
-						),
+						'global'   => [
+							'default' => Global_Colors::COLOR_ACCENT,
+						],
 					),
 				),
 			)
@@ -744,10 +743,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 				'selector'       => '{{WRAPPER}} a.elementor-button:hover, {{WRAPPER}} .elementor-button:hover',
 				'fields_options' => array(
 					'color' => array(
-						'scheme' => array(
-							'type'  => Color::get_type(),
-							'value' => Color::COLOR_4,
-						),
+						'global'   => [
+							'default' => Global_Colors::COLOR_ACCENT,
+						],
 					),
 				),
 			)
@@ -849,10 +847,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-infobox__separator' => 'border-top-color: {{VALUE}};',
 				),
@@ -1100,10 +1097,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			array(
 				'label'      => __( 'Icon Color', 'responsive-addons-for-elementor' ),
 				'type'       => Controls_Manager::COLOR,
-				'scheme'     => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'     => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'conditions' => array(
 					'relation' => 'and',
 					'terms'    => array(
@@ -1132,10 +1128,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Background Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'default'   => '',
 				'condition' => array(
 					'rael_image_type' => array( 'icon', 'photo' ),
@@ -1173,10 +1168,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Border Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'condition' => array(
 					'rael_image_type'   => array( 'icon', 'photo' ),
 					'rael_icon_border!' => 'none',
@@ -1902,7 +1896,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'rael_title_typography',
-				'scheme'    => Typography::TYPOGRAPHY_1,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector'  => '{{WRAPPER}} .rael-infobox__title',
 				'condition' => array(
 					'rael_title!' => '',
@@ -1914,10 +1910,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'default'   => '',
 				'condition' => array(
 					'rael_title!' => '',
@@ -1970,7 +1965,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'rael_description_typography',
-				'scheme'    => Typography::TYPOGRAPHY_3,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector'  => '{{WRAPPER}} .rael-infobox__description',
 				'condition' => array(
 					'rael_description!' => '',
@@ -1982,10 +1979,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Description Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'default'   => '',
 				'condition' => array(
 					'rael_description!' => '',
@@ -2024,7 +2020,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'rael_cta_typography',
-				'scheme'    => Typography::TYPOGRAPHY_2,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'selector'  => '{{WRAPPER}} .rael-infobox__cta-link, {{WRAPPER}} .elementor-button, {{WRAPPER}} a.elementor-button',
 				'condition' => array(
 					'rael_cta_type' => array( 'link', 'button' ),
@@ -2036,10 +2034,9 @@ class Responsive_Addons_For_Elementor_Icon_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Link Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-infobox__cta-link' => 'color: {{VALUE}};',
 				),

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-image-gallery.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-image-gallery.php
@@ -13,8 +13,8 @@ use Elementor\Controls_Manager;
 use Elementor\Repeater;
 use Elementor\Group_Control_Image_Size;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Color;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Border;
 use Elementor\Control_Media;
 
@@ -1746,7 +1746,9 @@ class Responsive_Addons_For_Elementor_Image_Gallery extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'all_typography',
-				'scheme'    => Typography::TYPOGRAPHY_4,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'condition' => array(
 					'rael_gallery_style'          => array( 'grid', 'masonry', 'justified' ),
 					'rael_masonry_filters_enable' => 'yes',
@@ -1829,10 +1831,9 @@ class Responsive_Addons_For_Elementor_Image_Gallery extends Widget_Base {
 			array(
 				'label'     => __( 'Text Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-img-gallery-tabs-dropdown .rael-filters-dropdown-button, {{WRAPPER}} .rael-gallery-parent .rael-masonry-filters .rael-masonry-filter' => 'color: {{VALUE}};',
 				),
@@ -1905,10 +1906,9 @@ class Responsive_Addons_For_Elementor_Image_Gallery extends Widget_Base {
 			array(
 				'label'     => __( 'Background Active / Hover Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-gallery-parent .rael-masonry-filters .rael-masonry-filter:hover, {{WRAPPER}} .rael-gallery-parent .rael-masonry-filters .rael-current' => 'background-color: {{VALUE}};',
 				),
@@ -1924,10 +1924,9 @@ class Responsive_Addons_For_Elementor_Image_Gallery extends Widget_Base {
 			array(
 				'label'     => __( 'Border Hover Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-gallery-parent .rael-masonry-filters .rael-masonry-filter:hover, {{WRAPPER}} .rael-gallery-parent .rael-masonry-filters .rael-current' => 'border-color: {{VALUE}};',
 				),

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-logo-carousel.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-logo-carousel.php
@@ -9,7 +9,7 @@
 namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Widget_Base;
 use Elementor\Repeater;
 use Elementor\Group_Control_Background;
@@ -685,7 +685,9 @@ class Responsive_Addons_For_Elementor_Logo_Carousel extends Widget_Base {
 			array(
 				'name'     => 'rael_logo_title_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '{{WRAPPER}} .rael-logo-carousel__item-title',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-multi-button.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-multi-button.php
@@ -12,7 +12,7 @@ use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Control_Icon;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Border;
 
@@ -450,7 +450,9 @@ class Responsive_Addons_For_Elementor_Multi_Button extends Widget_Base {
 				'name'     => 'rael_button_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
 				'selector' => '{{WRAPPER}} .rael-multi-button',
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 			)
 		);
 
@@ -560,7 +562,9 @@ class Responsive_Addons_For_Elementor_Multi_Button extends Widget_Base {
 			array(
 				'name'     => $id_prefix . '_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '{{WRAPPER}} .rael-multi-button__' . $type . '-btn',
 			)
 		);
@@ -708,7 +712,9 @@ class Responsive_Addons_For_Elementor_Multi_Button extends Widget_Base {
 			array(
 				'name'     => 'rael_connector_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-multi-button__connector',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-offcanvas.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-offcanvas.php
@@ -14,7 +14,6 @@ use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -820,7 +819,9 @@ class RAEL_Offcanvas extends Widget_Base {
 			array(
 				'name'     => 'text_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '.rael-offcanvas-content-{{ID}} .rael-offcanvas-body, .rael-offcanvas-content-{{ID}} .rael-offcanvas-body *:not(.fas):not(.eicon):not(.fab):not(.far):not(.fa)',
 			)
 		);
@@ -863,7 +864,9 @@ class RAEL_Offcanvas extends Widget_Base {
 			array(
 				'name'     => 'links_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '.rael-offcanvas-content-{{ID}} .rael-offcanvas-body a',
 			)
 		);
@@ -923,7 +926,9 @@ class RAEL_Offcanvas extends Widget_Base {
 			array(
 				'name'     => 'rael_offcanvas_title_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '.rael-offcanvas-content-{{ID}} .rael-offcanvas-title h3',
 			)
 		);
@@ -1168,7 +1173,9 @@ class RAEL_Offcanvas extends Widget_Base {
 			array(
 				'name'     => 'button_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '{{WRAPPER}} .rael-offcanvas-toggle',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-one-page-navigation.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-one-page-navigation.php
@@ -10,7 +10,7 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use \Elementor\Controls_Manager;
 use \Elementor\Group_Control_Background;
-use \Elementor\Core\Schemes\Typography;
+use \Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use \Elementor\Group_Control_Border;
 use \Elementor\Group_Control_Box_Shadow;
 use \Elementor\Group_Control_Typography;
@@ -656,7 +656,9 @@ class Responsive_Addons_For_Elementor_One_Page_Navigation extends Widget_Base {
 			array(
 				'name'      => 'rael_tooltip_typography',
 				'label'     => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'    => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector'  => '{{WRAPPER}} .rael-nav-dot-tooltip',
 				'condition' => array(
 					'rael_nav_tooltip' => 'yes',

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-post-carousel.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-post-carousel.php
@@ -14,7 +14,7 @@ use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Responsive_Addons_For_Elementor\Helper\Helper;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -1709,7 +1709,9 @@ class Responsive_Addons_For_Elementor_Post_Carousel extends Widget_Base {
 			array(
 				'name'     => 'rael_post_title_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .rael-post-carousel__entry-title, {{WRAPPER}} .rael-post-carousel__entry-title > a',
 			)
 		);
@@ -1782,7 +1784,9 @@ class Responsive_Addons_For_Elementor_Post_Carousel extends Widget_Base {
 			array(
 				'name'     => 'rael_post_excerpt_typography',
 				'label'    => __( 'Excerpt Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-post-carousel__excerpt p',
 			)
 		);
@@ -1835,7 +1839,9 @@ class Responsive_Addons_For_Elementor_Post_Carousel extends Widget_Base {
 			array(
 				'name'     => 'rael_post_terms_typography',
 				'label'    => __( 'Meta Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-post-carousel__meta-categories li a, {{WRAPPER}} .rael-post-carousel__meta-categories li, {{WRAPPER}} .rael-post-carousel__meta-categories li a',
 			)
 		);
@@ -1899,7 +1905,9 @@ class Responsive_Addons_For_Elementor_Post_Carousel extends Widget_Base {
 			array(
 				'name'     => 'rael_post_meta_date_typography',
 				'label'    => __( 'Meta Date Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-post-carousel__meta-posted-on',
 			)
 		);
@@ -2006,7 +2014,9 @@ class Responsive_Addons_For_Elementor_Post_Carousel extends Widget_Base {
 			array(
 				'name'     => 'rael_post_meta_header_typography',
 				'label'    => __( 'Meta Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-post-carousel__entry-meta > span,{{WRAPPER}} .rael-post-carousel__entry-meta > .rael-post-carousel__posted-by,{{WRAPPER}} .rael-post-carousel__entry-meta > .rael-post-carousel__meta-posted-on',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-posts.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-posts.php
@@ -12,7 +12,6 @@ use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Responsive_Addons_For_Elementor\WidgetsManager\Widgets\Skins;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes;
 use Responsive_Addons_For_Elementor\WidgetsManager\Modules\QueryControl\Module as Module_Query;
 use Responsive_Addons_For_Elementor\WidgetsManager\Modules\QueryControl\Controls\Group_Control_Related;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
@@ -375,7 +374,9 @@ class Responsive_Addons_For_Elementor_Posts extends Widget_Base {
 			array(
 				'name'      => 'pagination_typography',
 				'selector'  => '{{WRAPPER}} .elementor-pagination',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_2,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'condition' => array(
 					'pagination_type!' => 'infinite',
 				),

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-price-box.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-price-box.php
@@ -10,9 +10,9 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Icons_Manager;
-use Elementor\Core\Schemes\Typography;
 use Elementor\Group_Control_Typography;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
@@ -474,10 +474,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'      => __( 'Icon Color', 'responsive-addons-for-elementor' ),
 				'type'       => Controls_Manager::COLOR,
-				'scheme'     => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'     => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'conditions' => array(
 					'relation' => 'and',
 					'terms'    => array(
@@ -1112,10 +1111,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Background Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-box-header' => 'background-color: {{VALUE}};',
 				),
@@ -1196,10 +1194,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 					array(
 						'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 						'type'      => Controls_Manager::COLOR,
-						'scheme'    => array(
-							'type'  => Color::get_type(),
-							'value' => Color::COLOR_3,
-						),
+						'global'    => [
+							'default' => Global_Colors::COLOR_TEXT,
+						],
 						'default'   => '',
 						'selectors' => array(
 							'{{WRAPPER}} .rael-price-box-header__icon i' => 'color: {{VALUE}};',
@@ -1243,10 +1240,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 					array(
 						'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 						'type'      => Controls_Manager::COLOR,
-						'scheme'    => array(
-							'type'  => Color::get_type(),
-							'value' => Color::COLOR_3,
-						),
+						'global'    => [
+							'default' => Global_Colors::COLOR_TEXT,
+						],
 						'default'   => '',
 						'selectors' => array(
 							'{{WRAPPER}} .rael-price-box-header__icon i:hover' => 'color: {{VALUE}};',
@@ -1308,10 +1304,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-box__heading' => 'color: {{VALUE}}',
 				),
@@ -1322,7 +1317,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'     => 'rael_heading_typography',
 				'selector' => '{{WRAPPER}} .rael-price-box__heading',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -1363,10 +1360,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'condition' => array(
 					'rael_price_box_layout!' => '2',
 				),
@@ -1380,7 +1376,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'      => 'rael_description_typography',
 				'selector'  => '{{WRAPPER}} .rael-price-box-description',
-				'scheme'    => Typography::TYPOGRAPHY_2,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'condition' => array(
 					'rael_price_box_layout!' => '2',
 				),
@@ -1435,10 +1433,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'condition' => array(
 					'rael_price_box_layout' => '2',
 				),
@@ -1452,7 +1449,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'      => 'rael_description_typography_layout_2',
 				'selector'  => '{{WRAPPER}} .rael-price-box-description',
-				'scheme'    => Typography::TYPOGRAPHY_2,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'condition' => array(
 					'rael_price_box_layout' => '2',
 				),
@@ -1594,7 +1593,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'     => 'rael_price_typography',
 				'selector' => '{{WRAPPER}} .rael-pricing-value',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -1752,10 +1753,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-box__original-price' => 'color: {{VALUE}};',
 				),
@@ -1771,7 +1771,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'      => 'rael_original_price_typography',
 				'selector'  => '{{WRAPPER}} .rael-price-box__original-price',
-				'scheme'    => Typography::TYPOGRAPHY_1,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'condition' => array(
 					'rael_sale'            => 'yes',
 					'rael_original_price!' => '',
@@ -1832,10 +1834,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-box__duration' => 'color: {{VALUE}}',
 				),
@@ -1850,7 +1851,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'      => 'rael_duration_typography',
 				'selector'  => '{{WRAPPER}} .rael-price-box__duration',
-				'scheme'    => Typography::TYPOGRAPHY_2,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'condition' => array(
 					'rael_duration!' => '',
 				),
@@ -2025,10 +2028,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Text Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-box__features-list' => 'color: {{VALUE}}',
 				),
@@ -2040,7 +2042,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'     => 'rael_features_list_typography',
 				'selector' => '{{WRAPPER}} .rael-price-box__features-list li',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			)
 		);
 
@@ -2134,10 +2138,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '#ddd',
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'condition' => array(
 					'rael_price_features_layout' => array( 'divider', 'borderbox' ),
 				),
@@ -2499,10 +2502,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Text Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} a.rael-price-box__cta-link' => 'color: {{VALUE}};',
 				),
@@ -2517,7 +2519,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'      => 'rael_link_typography',
 				'selector'  => '{{WRAPPER}} a.rael-price-box__cta-link',
-				'scheme'    => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'condition' => array(
 					'rael_price_cta_type' => 'link',
 				),
@@ -2575,7 +2579,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'      => 'rael_button_typography',
 				'selector'  => '{{WRAPPER}} .elementor-button, {{WRAPPER}} a.elementor-button',
-				'scheme'    => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'condition' => array(
 					'rael_price_cta_type' => 'button',
 				),
@@ -2650,10 +2656,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 				array(
 					'label'     => __( 'Background Color', 'responsive-addons-for-elementor' ),
 					'type'      => Controls_Manager::COLOR,
-					'scheme'    => array(
-						'type'  => Color::get_type(),
-						'value' => Color::COLOR_4,
-					),
+					'global'    => [
+						'default' => Global_Colors::COLOR_ACCENT,
+					],
 					'selectors' => array(
 						'{{WRAPPER}} .elementor-button' => 'background-color: {{VALUE}};',
 					),
@@ -2850,10 +2855,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-box__disclaimer' => 'color: {{VALUE}}',
 				),
@@ -2867,7 +2871,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'      => 'rael_additional_info_typography',
 				'selector'  => '{{WRAPPER}} .rael-price-box__disclaimer',
-				'scheme'    => Typography::TYPOGRAPHY_3,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'condition' => array(
 					'rael_disclaimer_text!' => '',
 				),
@@ -3032,10 +3038,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'label'     => __( 'Background Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_4,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-box-ribbon-content' => 'background-color: {{VALUE}}',
 					'{{WRAPPER}} .rael-price-box-ribbon-3 .rael-price-box-ribbon-content:before' => 'border-left: 8px solid {{VALUE}};',
@@ -3076,7 +3081,9 @@ class Responsive_Addons_For_Elementor_Price_Box extends Widget_Base {
 			array(
 				'name'     => 'rael_ribbon_typography',
 				'selector' => '{{WRAPPER}} .rael-price-box-ribbon-content',
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 			)
 		);
 

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-price-list.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-price-list.php
@@ -10,7 +10,8 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Image_Size;
@@ -307,7 +308,9 @@ class Responsive_Addons_For_Elementor_Price_List extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'heading_typography',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .rael-price-list-header',
 			)
 		);
@@ -317,10 +320,9 @@ class Responsive_Addons_For_Elementor_Price_List extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-list-title' => 'color: {{VALUE}};',
 					'{{WRAPPER}} .rael-price-list .rael-price-list-price' => 'color: {{VALUE}};',
@@ -373,7 +375,9 @@ class Responsive_Addons_For_Elementor_Price_List extends Widget_Base {
 			array(
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
 				'name'     => 'badge_typography',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'exclude'  => array(
 					'letter_spacing',
 				),
@@ -474,7 +478,9 @@ class Responsive_Addons_For_Elementor_Price_List extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'original_price_typography',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-price-list-original-price',
 			)
 		);
@@ -493,10 +499,9 @@ class Responsive_Addons_For_Elementor_Price_List extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_3,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-list-description' => 'color: {{VALUE}};',
 				),
@@ -507,7 +512,9 @@ class Responsive_Addons_For_Elementor_Price_List extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'description_typography',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-price-list-description',
 			)
 		);
@@ -568,10 +575,9 @@ class Responsive_Addons_For_Elementor_Price_List extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-list-separator' => 'border-bottom-color: {{VALUE}};',
 				),

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-pricing-table.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-pricing-table.php
@@ -10,7 +10,8 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Typography;
@@ -420,10 +421,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'label'     => __( 'Background Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-table__header' => 'background-color: {{VALUE}}',
 				),
@@ -467,7 +467,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'name'     => 'heading_typography',
 				'selector' => '{{WRAPPER}} .rael-price-table__heading',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -496,7 +498,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'name'     => 'sub_heading_typography',
 				'selector' => '{{WRAPPER}} .rael-price-table__subheading',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_2,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 			)
 		);
 
@@ -551,7 +555,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'name'     => 'price_typography',
 				'selector' => '{{WRAPPER}} .rael-price-table__price span:not(.rael-price-table__period), {{WRAPPER}} .rael-price-table__price > .rael-price-table__after-price > .rael-price-table__fractional-part',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -715,10 +721,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-table__original-price' => 'color: {{VALUE}}',
 				),
@@ -734,7 +739,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'name'      => 'original_price_typography',
 				'selector'  => '{{WRAPPER}} .rael-price-table__original-price',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'condition' => array(
 					'sale'            => 'yes',
 					'original_price!' => '',
@@ -794,10 +801,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-table__period' => 'color: {{VALUE}}',
 				),
@@ -812,7 +818,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'name'      => 'period_typography',
 				'selector'  => '{{WRAPPER}} .rael-price-table__period',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_2,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'condition' => array(
 					'period!' => '',
 				),
@@ -876,10 +884,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_3,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'separator' => 'before',
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-table__features-list' => 'color: {{VALUE}}',
@@ -892,7 +899,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'name'     => 'features_list_typography',
 				'selector' => '{{WRAPPER}} .rael-price-table__features-list li',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			)
 		);
 
@@ -975,10 +984,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '#ddd',
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_3,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'condition' => array(
 					'list_divider' => 'yes',
 				),
@@ -1143,7 +1151,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'button_typography',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '{{WRAPPER}} .rael-price-table__button',
 			)
 		);
@@ -1153,10 +1163,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'label'     => __( 'Background Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_4,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-table__button' => 'background-color: {{VALUE}};',
 				),
@@ -1270,10 +1279,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_3,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-table__additional_info' => 'color: {{VALUE}}',
 				),
@@ -1288,7 +1296,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'name'      => 'additional_info_typography',
 				'selector'  => '{{WRAPPER}} .rael-price-table__additional_info',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_3,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'condition' => array(
 					'footer_additional_info!' => '',
 				),
@@ -1336,10 +1346,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'label'     => __( 'Background Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_4,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-price-table__ribbon-inner' => 'background-color: {{VALUE}}',
 				),
@@ -1383,7 +1392,9 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 			array(
 				'name'     => 'ribbon_typography',
 				'selector' => '{{WRAPPER}} .rael-price-table__ribbon-inner',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 			)
 		);
 

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-progress-bar.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-progress-bar.php
@@ -13,7 +13,7 @@ use Elementor\Controls_Manager;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -777,7 +777,9 @@ class Responsive_Addons_For_Elementor_Progress_Bar extends Widget_Base {
 			array(
 				'name'     => 'progress_bar_title_typography',
 				'label'    => __( 'Title', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .rael-progressbar-title',
 			)
 		);
@@ -800,7 +802,9 @@ class Responsive_Addons_For_Elementor_Progress_Bar extends Widget_Base {
 			array(
 				'name'     => 'progress_bar_count_typography',
 				'label'    => __( 'Counter', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .rael-progressbar-count-wrap',
 			)
 		);
@@ -823,7 +827,9 @@ class Responsive_Addons_For_Elementor_Progress_Bar extends Widget_Base {
 			array(
 				'name'      => 'progress_bar_after_typography',
 				'label'     => __( 'Prefix/Postfix', 'responsive-addons-for-elementor' ),
-				'scheme'    => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector'  => '{{WRAPPER}} .rael-progressbar-half-circle-after span',
 				'condition' => array(
 					'rael_progress_bar_layout' => 'half_circle',

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-slider.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-slider.php
@@ -10,9 +10,9 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Repeater;
 use Elementor\Controls_Manager;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Text_Shadow;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -857,7 +857,9 @@ class Responsive_Addons_For_Elementor_Slider extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'heading_typography',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .responsive-slide-heading',
 			)
 		);
@@ -905,7 +907,9 @@ class Responsive_Addons_For_Elementor_Slider extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'description_typography',
-				'scheme'   => Schemes\Typography::TYPOGRAPHY_2,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'selector' => '{{WRAPPER}} .responsive-slide-description',
 			)
 		);
@@ -934,7 +938,9 @@ class Responsive_Addons_For_Elementor_Slider extends Widget_Base {
 			\Elementor\Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'button_typography',
-				'scheme'   => \Elementor\Core\Schemes\Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .responsive-slide-button',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-team-member.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-team-member.php
@@ -10,9 +10,7 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use Elementor\Group_Control_Image_Size;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Color;
 use Elementor\Widget_Base;
 use Elementor\Repeater;
 use Elementor\Utils;

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-testimonial-slider.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-testimonial-slider.php
@@ -17,8 +17,8 @@ use Elementor\Repeater;
 use Elementor\Utils;
 use Elementor\Group_Control_Image_Size;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Color;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Background;
 use Elementor\Icons_Manager;
@@ -691,10 +691,9 @@ class Responsive_Addons_For_Elementor_Testimonial_Slider extends Widget_Base {
 				'selectors' => array(
 					'{{WRAPPER}} .responsive-testimonial__text' => 'color: {{VALUE}}',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 			)
 		);
 
@@ -703,7 +702,9 @@ class Responsive_Addons_For_Elementor_Testimonial_Slider extends Widget_Base {
 			array(
 				'name'     => 'content_typography',
 				'selector' => '{{WRAPPER}} .responsive-testimonial__text',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			)
 		);
 
@@ -724,10 +725,9 @@ class Responsive_Addons_For_Elementor_Testimonial_Slider extends Widget_Base {
 				'selectors' => array(
 					'{{WRAPPER}} .responsive-testimonial__name' => 'color: {{VALUE}}',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_3,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_TEXT,
+				],
 			)
 		);
 
@@ -736,7 +736,9 @@ class Responsive_Addons_For_Elementor_Testimonial_Slider extends Widget_Base {
 			array(
 				'name'     => 'name_typography',
 				'selector' => '{{WRAPPER}} .responsive-testimonial__name',
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			)
 		);
 
@@ -757,10 +759,9 @@ class Responsive_Addons_For_Elementor_Testimonial_Slider extends Widget_Base {
 				'selectors' => array(
 					'{{WRAPPER}} .responsive-testimonial__title' => 'color: {{VALUE}}',
 				),
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 			)
 		);
 
@@ -769,7 +770,9 @@ class Responsive_Addons_For_Elementor_Testimonial_Slider extends Widget_Base {
 			array(
 				'name'     => 'title_typography',
 				'selector' => '{{WRAPPER}} .responsive-testimonial__title',
-				'scheme'   => Typography::TYPOGRAPHY_2,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 			)
 		);
 

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-timeline.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-timeline.php
@@ -12,7 +12,7 @@ use Elementor\Widget_Base;
 use Elementor\Utils;
 use Elementor\Repeater;
 use Elementor\Control_Media;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Icons_Manager;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
@@ -674,7 +674,9 @@ class Responsive_Addons_For_Elementor_Timeline extends Widget_Base {
 			array(
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
 				'name'     => 'rael_content_box',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-timeline__content',
 			)
 		);
@@ -1007,7 +1009,9 @@ class Responsive_Addons_For_Elementor_Timeline extends Widget_Base {
 			array(
 				'name'     => 'rael_title',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .rael-timeline__title',
 			)
 		);
@@ -1088,7 +1092,9 @@ class Responsive_Addons_For_Elementor_Timeline extends Widget_Base {
 			array(
 				'name'      => 'rael_time',
 				'label'     => __( 'Time Typography', 'responsive-addons-for-elementor' ),
-				'scheme'    => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector'  => '{{WRAPPER}} .rael-timeline__date .time',
 				'condition' => array(
 					'rael_show_time' => 'yes',
@@ -1152,7 +1158,9 @@ class Responsive_Addons_For_Elementor_Timeline extends Widget_Base {
 			array(
 				'label'     => __( 'Date Typography', 'responsive-addons-for-elementor' ),
 				'name'      => 'rael_time_date',
-				'scheme'    => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector'  => '{{WRAPPER}} .rael-timeline__date .date',
 				'condition' => array(
 					'rael_show_date' => 'yes',
@@ -1212,7 +1220,9 @@ class Responsive_Addons_For_Elementor_Timeline extends Widget_Base {
 			array(
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
 				'name'     => 'rael_button',
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '{{WRAPPER}} .rael-timeline__button',
 			)
 		);

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-twitter-feed.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-twitter-feed.php
@@ -14,7 +14,7 @@ use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 
 /**
  * 'RAEL Twitter Feed' widget class
@@ -865,10 +865,9 @@ class Responsive_Addons_For_Elementor_Twitter_Feed extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-twitter-feed__twitter-icon' => 'color: {{VALUE}};',
 				),

--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-wpf-styler.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-wpf-styler.php
@@ -12,12 +12,12 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets;
 
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Background;
-use Elementor\Core\Schemes\Typography;
 use Responsive_Addons_For_Elementor\Traits\Missing_Dependency;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -426,10 +426,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Label Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'default'   => '',
 				'selectors' => array(
 					'{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field-label,
@@ -454,10 +453,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Input Text / Placeholder Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field input:not([type=submit]):not([type=image]):not([type=button]):not([type=file]):not([type=radio]):not([type=checkbox]),
 						{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field input::placeholder,
@@ -478,10 +476,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Sublabel / Description Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'default'   => '',
 				'selectors' => array(
 					'{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field-description,
@@ -780,10 +777,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Selected Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'condition' => array(
 					'wpf_radio_check_custom!' => '',
 				),
@@ -1167,7 +1163,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'wpf_message_typo',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-wpf-style label.wpforms-error',
 			)
 		);
@@ -1223,7 +1221,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'     => 'wpf_validation_typo',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-wpf-style .wpforms-confirmation-container-full,
 					{{WRAPPER}} .rael-wpf-style .wpforms-confirmation-container',
 			)
@@ -1471,7 +1471,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'title_typography',
-				'scheme'    => Typography::TYPOGRAPHY_1,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector'  => '{{WRAPPER}} .rael-wpf-style .wpforms-title',
 				'condition' => array(
 					'form_title_desc_option!' => 'none',
@@ -1484,10 +1486,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_1,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
+				],
 				'condition' => array(
 					'form_title_desc_option!' => 'none',
 				),
@@ -1515,7 +1516,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'desc_typography',
-				'scheme'    => Typography::TYPOGRAPHY_2,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'selector'  => '{{WRAPPER}} .rael-wpf-style .wpforms-description',
 				'condition' => array(
 					'form_title_desc_option!' => 'none',
@@ -1528,10 +1531,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Color::get_type(),
-					'value' => Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'condition' => array(
 					'form_title_desc_option!' => 'none',
 				),
@@ -1556,7 +1558,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'name'     => 'form_label_typography',
 				'label'    => 'Label Typography',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field-label,
 									{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field-radio li label,
 									{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field-checkbox li label,
@@ -1580,7 +1584,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'name'     => 'input_typography',
 				'label'    => 'Input Text Typography',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field input:not([type=submit]):not([type=image]):not([type=button]):not([type=file]):not([type=radio]):not([type=checkbox]),
 						{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field input::placeholder,
 						{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field textarea,
@@ -1596,7 +1602,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'name'     => 'input_desc_typography',
 				'label'    => 'Sublabel / Description Typography',
-				'scheme'   => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector' => '{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field-description,
 									{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field-sublabel,
 									{{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-field-likert_scale thead tr th',
@@ -1617,7 +1625,9 @@ class Responsive_Addons_For_Elementor_WPF_Styler extends Widget_Base {
 			array(
 				'name'     => 'btn_typography',
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '{{WRAPPER}} .rael-wpf-style .wpforms-form button[type=submit], {{WRAPPER}} .rael-wpf-style .wpforms-form .wpforms-page-button',
 			)
 		);

--- a/includes/widgets-manager/widgets/skins/class-rael-skin-base.php
+++ b/includes/widgets-manager/widgets/skins/class-rael-skin-base.php
@@ -8,14 +8,14 @@
 namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets\Skins;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Schemes;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Css_Filter;
 use Elementor\Group_Control_Image_Size;
 use Elementor\Group_Control_Typography;
 use Elementor\Skin_Base as Elementor_Skin_Base;
 use Elementor\Widget_Base;
 use Elementor\Plugin;
-use Elementor\Core\Schemes\Color;
 use Elementor\Group_Control_Box_Shadow;
 use Responsive_Addons_For_Elementor\Helper\Helper;
 
@@ -701,10 +701,9 @@ abstract class RAEL_Skin_Base extends Elementor_Skin_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_2,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .elementor-post__title, {{WRAPPER}} .elementor-post__title a' => 'color: {{VALUE}};',
 				),
@@ -718,7 +717,9 @@ abstract class RAEL_Skin_Base extends Elementor_Skin_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'title_typography',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_1,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector'  => '{{WRAPPER}} .elementor-post__title, {{WRAPPER}} .elementor-post__title a',
 				'condition' => array(
 					$this->get_control_id( 'show_title' ) => 'yes',
@@ -789,7 +790,9 @@ abstract class RAEL_Skin_Base extends Elementor_Skin_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'meta_typography',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_2,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'selector'  => '{{WRAPPER}} .elementor-post__meta-data',
 				'condition' => array(
 					$this->get_control_id( 'meta_data!' ) => array(),
@@ -846,7 +849,9 @@ abstract class RAEL_Skin_Base extends Elementor_Skin_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'excerpt_typography',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'selector'  => '{{WRAPPER}} .elementor-post__excerpt p',
 				'condition' => array(
 					$this->get_control_id( 'show_excerpt' ) => 'yes',
@@ -890,10 +895,9 @@ abstract class RAEL_Skin_Base extends Elementor_Skin_Base {
 			array(
 				'label'     => __( 'Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_4,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .elementor-post__read-more' => 'color: {{VALUE}};',
 				),
@@ -908,10 +912,9 @@ abstract class RAEL_Skin_Base extends Elementor_Skin_Base {
 			array(
 				'label'     => __( 'Hover Color', 'responsive-addons-for-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_4,
-				),
+				'global'    => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'selectors' => array(
 					'{{WRAPPER}} .elementor-post__read-more:hover' => 'color: {{VALUE}};',
 				),
@@ -927,7 +930,9 @@ abstract class RAEL_Skin_Base extends Elementor_Skin_Base {
 			array(
 				'name'      => 'read_more_typography',
 				'selector'  => '{{WRAPPER}} .elementor-post__read-more',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'condition' => array(
 					$this->get_control_id( 'show_read_more' ) => 'yes',
 					$this->get_control_id( 'read_more_type' ) => 'text',
@@ -960,7 +965,9 @@ abstract class RAEL_Skin_Base extends Elementor_Skin_Base {
 			array(
 				'name'      => 'read_more_button_typography',
 				'selector'  => '{{WRAPPER}} .elementor-button-text',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_4,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'condition' => array(
 					$this->get_control_id( 'show_read_more' ) => 'yes',
 					$this->get_control_id( 'read_more_type' ) => 'button',
@@ -1041,10 +1048,9 @@ abstract class RAEL_Skin_Base extends Elementor_Skin_Base {
 					array(
 						'label'     => __( 'Background Color', 'responsive-addons-for-elementor' ),
 						'type'      => Controls_Manager::COLOR,
-						'scheme'    => array(
-							'type'  => Color::get_type(),
-							'value' => Color::COLOR_4,
-						),
+						'global'    => [
+							'default' => Global_Colors::COLOR_ACCENT,
+						],
 						'selectors' => array(
 							'{{WRAPPER}} .elementor-button' => 'background-color: {{VALUE}};',
 						),

--- a/includes/widgets-manager/widgets/skins/class-rael-skin-cards.php
+++ b/includes/widgets-manager/widgets/skins/class-rael-skin-cards.php
@@ -8,11 +8,11 @@
 namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets\Skins;
 
 use Elementor\Controls_Manager;
-use Elementor\Group_Control_Box_Shadow;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Image_Size;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -463,10 +463,9 @@ class RAEL_Skin_Cards extends RAEL_Skin_Base {
 				'selectors' => array(
 					'{{WRAPPER}} .elementor-post__card .elementor-post__badge' => 'background-color: {{VALUE}};',
 				),
-				'scheme'    => array(
-					'type'  => Schemes\Color::get_type(),
-					'value' => Schemes\Color::COLOR_4,
-				),
+				'global'   => [
+					'default' => Global_Colors::COLOR_ACCENT,
+				],
 				'condition' => array(
 					$this->get_control_id( 'show_badge' ) => 'yes',
 				),
@@ -552,7 +551,9 @@ class RAEL_Skin_Cards extends RAEL_Skin_Base {
 			Group_Control_Typography::get_type(),
 			array(
 				'name'      => 'badge_typography',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_4,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector'  => '{{WRAPPER}} .elementor-post__card .elementor-post__badge',
 				'exclude'   => array( 'font_size', 'line-height' ),
 				'condition' => array(

--- a/includes/widgets-manager/widgets/skins/product-category-grid/rael-skin-classic.php
+++ b/includes/widgets-manager/widgets/skins/product-category-grid/rael-skin-classic.php
@@ -11,7 +11,7 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets\Skins\Product_C
 use Elementor\Controls_Manager;
 use Elementor\Skin_Base;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Border;
 use Elementor\Widget_Base;
@@ -164,7 +164,9 @@ class RAEL_Skin_Classic extends Skin_Base {
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
 				'name'     => 'rael_content_title_typography',
 				'selector' => '{{WRAPPER}} .rael-product-category-grid__content-title a',
-				'scheme'   => Typography::TYPOGRAPHY_2,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 			)
 		);
 
@@ -229,7 +231,9 @@ class RAEL_Skin_Classic extends Skin_Base {
 				'label'     => __( 'Typography', 'responsive-addons-for-elementor' ),
 				'name'      => 'rael_content_count_typography',
 				'selector'  => '{{WRAPPER}} .rael-product-category-grid__product-count',
-				'scheme'    => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'condition' => array(
 					'rael_show_product_count' => 'yes',
 				),

--- a/includes/widgets-manager/widgets/skins/product-category-grid/rael-skin-minimal.php
+++ b/includes/widgets-manager/widgets/skins/product-category-grid/rael-skin-minimal.php
@@ -11,7 +11,7 @@ namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets\Skins\Product_C
 use Elementor\Controls_Manager;
 use Elementor\Skin_Base;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Border;
 use Elementor\Widget_Base;
@@ -188,7 +188,9 @@ class RAEL_Skin_Minimal extends Skin_Base {
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
 				'name'     => 'rael_content_title_typography',
 				'selector' => '{{WRAPPER}} .rael-product-category-grid__content-title a',
-				'scheme'   => Typography::TYPOGRAPHY_2,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 			)
 		);
 
@@ -253,7 +255,9 @@ class RAEL_Skin_Minimal extends Skin_Base {
 				'label'     => __( 'Typography', 'responsive-addons-for-elementor' ),
 				'name'      => 'rael_content_count_typography',
 				'selector'  => '{{WRAPPER}} .rael-product-category-grid__product-count',
-				'scheme'    => Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 				'condition' => array(
 					'rael_show_product_count' => 'yes',
 				),

--- a/includes/widgets-manager/widgets/theme-builder/class-responsive-addons-for-elementor-theme-product-price.php
+++ b/includes/widgets-manager/widgets/theme-builder/class-responsive-addons-for-elementor-theme-product-price.php
@@ -7,10 +7,10 @@
 
 namespace Responsive_Addons_For_Elementor\WidgetsManager\Widgets\ThemeBuilder;
 
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Responsive_Addons_For_Elementor\WidgetsManager\Widgets\ThemeBuilder\Woo_Widget_Base;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Controls_Manager;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/widgets-manager/widgets/woocommerce/class-responsive-addons-for-elementor-product-category-grid.php
+++ b/includes/widgets-manager/widgets/woocommerce/class-responsive-addons-for-elementor-product-category-grid.php
@@ -16,7 +16,7 @@ use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Responsive_Addons_For_Elementor\Traits\Missing_Dependency;
 
 use Responsive_Addons_For_Elementor\WidgetsManager\Widgets\Skins\Product_Category_Grid as Skins;
@@ -863,7 +863,9 @@ class Responsive_Addons_For_Elementor_Product_Category_Grid extends Widget_Base 
 			array(
 				'label'    => __( 'Typography', 'responsive-addons-for-elementor' ),
 				'name'     => 'rael_load_more_button',
-				'scheme'   => Typography::TYPOGRAPHY_4,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+				],
 				'selector' => '{{WRAPPER}} .rael-product-category-grid__load-more-button',
 			)
 		);

--- a/includes/widgets-manager/widgets/woocommerce/class-responsive-addons-for-elementor-woo-products.php
+++ b/includes/widgets-manager/widgets/woocommerce/class-responsive-addons-for-elementor-woo-products.php
@@ -15,8 +15,6 @@ use Elementor\Controls_Stack;
 use Responsive_Addons_For_Elementor\WidgetsManager\Modules\QueryControl\Controls\Group_Control_Query;
 use Responsive_Addons_For_Elementor\WidgetsManager\Modules\Woocommerce\Classes\Products_Renderer;
 use Responsive_Addons_For_Elementor\WidgetsManager\Modules\Woocommerce\Classes\Current_Query_Renderer;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
-use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;


### PR DESCRIPTION
The plugin is using the deprecated "**Schemes**" mechanism that had been replaced with "**Globals**" in Elementor 3.0.0 (in 2020).

Ref: https://developers.elementor.com/docs/deprecations/complex-example/