### PR TITLE
WP-6898 Fix custom html tag visible on Price Table

### DIFF
--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-pricing-table.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-pricing-table.php
@@ -1585,8 +1585,8 @@ class Responsive_Addons_For_Elementor_Pricing_Table extends Widget_Base {
 								endif;
 								?>
 								<?php if ( ! empty( $item['item_text'] ) ) : ?>
-									<span <?php echo esc_html( $this->get_render_attribute_string( $repeater_setting_key ) ); ?>>
-										<?php echo esc_html( $item['item_text'] ); ?>
+									<span <?php $this->print_render_attribute_string( $repeater_setting_key ); ?>>
+										<?php $this->print_unescaped_setting( 'item_text', 'features_list', $index ); ?>
 									</span>
 									<?php
 								else :


### PR DESCRIPTION
Task ID: WP-6898
The html tags are visible in frontend Price table, fixed it by changing esc_str to unescaped string