### PR TITLE
WP-7567 Fix timeline widget image alt text

### DIFF
--- a/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-timeline.php
+++ b/includes/widgets-manager/widgets/class-responsive-addons-for-elementor-timeline.php
@@ -1436,7 +1436,10 @@ class Responsive_Addons_For_Elementor_Timeline extends Widget_Base {
 				if ( ! empty( $value['rael_gallery'] ) && 'before' === $value['rael_image_position'] ) {
 					echo '<figure class="rael-timeline__image-gallery before-title">';
 					foreach ( $value['rael_gallery'] as $id => $image ) {
-									echo wp_get_attachment_image( $image['id'], $value['rael_image_size'], false, array( 'alt' => wp_get_attachment_caption( $image['id'] ) ) );
+						$alt_text = get_post_meta( $image['id'], '_wp_attachment_image_alt', true ); // Fetch alt text
+    					$alt_text = !empty( $alt_text ) ? esc_attr( $alt_text ) : ''; // escape alt text
+
+						echo wp_get_attachment_image( $image['id'], $value['rael_image_size'], false, array( 'alt' => $alt_text ) );
 					}
 					echo '</figure>';
 				}


### PR DESCRIPTION
Task ID: WP-7567
Fixed the alt text not visible for the image gallery in the timeline widget.